### PR TITLE
Rename PEP003 to Advanced Dependencies and mark as implementable

### DIFF
--- a/pep/003-advanced-dependencies.md
+++ b/pep/003-advanced-dependencies.md
@@ -1,5 +1,5 @@
 ---
-title: "Dependency Namespaces and Labels"
+title: "Advanced Dependencies"
 number: "003"
 status: "provisional"
 owner: "@carolynvs"

--- a/pep/003-advanced-dependencies.md
+++ b/pep/003-advanced-dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: "Advanced Dependencies"
 number: "003"
-status: "provisional"
+status: "implementable"
 owner: "@carolynvs"
 authors:
   - "@carolynvs"
@@ -424,7 +424,10 @@ When matching existing installations against the bundle interface, only outputs 
 
 ## Implementation
 
-All issues and pull requests are labeled with [pep003-advanced-dependencies](https://github.com/getporter/porter/issues?q=label%3Apep003-advanced-dependencies).
+All implementation work related to this PEP are labeled with `pep003-advanced-dependencies`.
+
+* [Issues](https://github.com/getporter/porter/issues?q=is%3Aissue+label%3Apep003-advanced-dependencies)
+* [Pull Requests](https://github.com/getporter/porter/pulls?q=is%3Apr+label%3Apep003-advanced-dependencies)
 
 ---
 


### PR DESCRIPTION
[Rename PEP003 to Advanced Dependencies](https://github.com/getporter/proposals/commit/f68154d6565c52b7a1746926ef0c74c8b10cb351)

I have updated the title of the PEP to better reflect how we have been talking about it the past year. Labels and namespaces are an implementation detail of dependency resolution but the entire PEP is really about advanced dependency scenarios.

[Mark PEP003 as implementable](https://github.com/getporter/proposals/commit/e7b7c0c6edd623c36f569e6a8500d770d034fa32)

Implementation is already underway and I have updated the PEP with links to open issues and pull requests.